### PR TITLE
Make transport less dependent on std

### DIFF
--- a/examples/send_framing.rs
+++ b/examples/send_framing.rs
@@ -28,7 +28,8 @@ fn main() {
     let message = Message::amqp_value(Value::String(args[4].to_string()));
 
     let opts = ConnectionOptions::new().sasl_mechanism(SaslMechanism::Anonymous);
-    let transport = Transport::connect(&host, port).expect("Error opening transport");
+    let net = MioNetwork::connect(&host, port).expect("Error opening network");
+    let transport = Transport::new(net, 1024);
     let mut connection = connect(transport, opts).expect("Error opening connection");
 
     connection.open(Open::new("example-send-minimal")).unwrap();

--- a/examples/send_framing.rs
+++ b/examples/send_framing.rs
@@ -28,7 +28,7 @@ fn main() {
     let message = Message::amqp_value(Value::String(args[4].to_string()));
 
     let opts = ConnectionOptions::new().sasl_mechanism(SaslMechanism::Anonymous);
-    let net = MioNetwork::connect(&host, port).expect("Error opening network");
+    let net = mio::MioNetwork::connect(&host, port).expect("Error opening network");
     let transport = Transport::new(net, 1024);
     let mut connection = connect(transport, opts).expect("Error opening connection");
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -208,7 +208,8 @@ impl ContainerInner {
     }
 
     async fn connect(&self, host: &str, port: u16, opts: ConnectionOptions) -> Result<Connection> {
-        let transport = transport::Transport::connect(host, port)?;
+        let network = transport::MioNetwork::connect(host, port)?;
+        let transport = transport::Transport::new(network, 1024);
         let mut driver = conn::connect(transport, opts)?;
         trace!("{}: connected to {}:{}", self.container_id, host, port);
 

--- a/src/container.rs
+++ b/src/container.rs
@@ -208,7 +208,7 @@ impl ContainerInner {
     }
 
     async fn connect(&self, host: &str, port: u16, opts: ConnectionOptions) -> Result<Connection> {
-        let network = transport::MioNetwork::connect(host, port)?;
+        let network = transport::mio::MioNetwork::connect(host, port)?;
         let transport = transport::Transport::new(network, 1024);
         let mut driver = conn::connect(transport, opts)?;
         trace!("{}: connected to {}:{}", self.container_id, host, port);

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -14,7 +14,7 @@ use crate::framing::{
     Performative, Source, Target, Transfer,
 };
 use crate::message::Message;
-use crate::transport::MioNetwork;
+use crate::transport::mio::MioNetwork;
 use log::{trace, warn};
 use mio::{Interest, Poll, Token};
 use rand::Rng;

--- a/src/sasl.rs
+++ b/src/sasl.rs
@@ -88,10 +88,10 @@ impl Sasl {
         self.state == SaslState::Success || self.state == SaslState::Failed
     }
 
-    pub fn perform_handshake(
+    pub fn perform_handshake<N: Network>(
         &mut self,
         hostname: Option<&str>,
-        transport: &mut Transport,
+        transport: &mut Transport<N>,
     ) -> Result<()> {
         match &self.role {
             SaslRole::Client(sasl_client) => {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -92,7 +92,7 @@ impl Buffer {
     fn new(capacity: usize) -> Buffer {
         Buffer {
             buffer: [0; BUFFER_SIZE],
-            capacity: capacity,
+            capacity,
             position: 0,
         }
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -118,7 +118,7 @@ impl Buffer {
     }
 
     fn written(&mut self) -> &[u8] {
-        return &self.buffer[0..self.position];
+        &self.buffer[0..self.position]
     }
 
     fn clear(&mut self) {
@@ -166,7 +166,7 @@ impl MioNetwork {
         let mut addrs = format!("{}:{}", host, port).to_socket_addrs().unwrap();
         let stream = TcpStream::connect(addrs.next().unwrap())?;
 
-        Ok(MioNetwork { stream: stream })
+        Ok(MioNetwork { stream })
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -134,7 +134,7 @@ impl Buffer {
                 "written data is bigger than output buffer",
             ));
         }
-        println!("Copying {} bytes into {}", data.len(), self.position);
+        // println!("Copying {} bytes into {}", data.len(), self.position);
         self.buffer[self.position..(self.position + data.len())].clone_from_slice(data);
         self.position += data.len();
         Ok(data.len())


### PR DESCRIPTION
* Introduce Network trait that removes the direct dependency on mio
* Use arrays for read and write buffers so that they do not require
  standard library