### PR TITLE
Support handing a message out to application

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -97,6 +97,7 @@ pub struct Disposition {
 /// Represent a delivery
 pub struct Delivery {
     settled: bool,
+    message: Option<Message>,
     waker: Arc<Waker>,
     link: Arc<LinkDriver>,
     delivery: Arc<DeliveryDriver>,
@@ -609,13 +610,14 @@ impl Receiver {
                         tag: transfer.delivery_tag.clone().unwrap(),
                         id: transfer.delivery_id.unwrap(),
                         remotely_settled: transfer.settled.unwrap_or(false),
+                        message: None,
                         settled: false,
-                        message,
                     });
                     return Ok(Delivery {
                         waker: self.waker.clone(),
                         settled: false,
                         link: self.link.clone(),
+                        message: Some(message),
                         delivery,
                     });
                 }
@@ -642,9 +644,14 @@ impl Drop for Receiver {
 }
 
 impl Delivery {
-    /// Retrieve the message associated with this delivery.
+    /// Retrieve reference to the message associated with this delivery.
     pub fn message(&self) -> &Message {
-        &self.delivery.message
+        &self.message.as_ref().unwrap()
+    }
+
+    // Take the message from the delivery to
+    pub fn take_message(&mut self) -> Option<Message> {
+        self.message.take()
     }
 
     /// Send a disposition for this delivery, indicating message settlement and delivery state.

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -131,7 +131,7 @@ pub struct LinkDriver {
 
 #[derive(Debug)]
 pub struct DeliveryDriver {
-    pub message: Message,
+    pub message: Option<Message>,
     pub remotely_settled: bool,
     pub settled: bool,
     pub state: Option<DeliveryState>,
@@ -648,7 +648,7 @@ impl LinkDriver {
         self.delivery_count.fetch_add(1, Ordering::SeqCst);
         let delivery_tag = rand::thread_rng().gen::<[u8; 16]>().to_vec();
         let delivery = Arc::new(DeliveryDriver {
-            message,
+            message: Some(message),
             id: next_outgoing_id,
             tag: delivery_tag.clone(),
             state: None,
@@ -678,7 +678,9 @@ impl LinkDriver {
         };
 
         let mut msgbuf = Vec::new();
-        delivery.message.encode(&mut msgbuf)?;
+        if let Some(message) = delivery.message.as_ref() {
+            message.encode(&mut msgbuf)?;
+        }
 
         self.driver
             .lock()


### PR DESCRIPTION
* Add method take_message() on delivery to pass ownership to
  application.
* Store message on delivery struct rather than driver for incoming
  messages.