### PR TITLE
Add method to check credits available on link

### DIFF
--- a/src/container.rs
+++ b/src/container.rs
@@ -645,6 +645,11 @@ impl Sender {
         }
     }
 
+    /// Retrieve credits available on this link. 0 means a send will fail with NotEnoughCreditsToSend.
+    pub fn credits(&self) -> u32 {
+        self.link.credits()
+    }
+
     /// Close the sender link, sending the detach performative.
     pub fn close(&self, error: Option<ErrorCondition>) -> Result<()> {
         self.link.close(error)

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -650,6 +650,10 @@ impl LinkDriver {
         &self.connection
     }
 
+    pub fn credits(&self) -> u32 {
+        self.credit.load(Ordering::SeqCst)
+    }
+
     pub async fn send_message(
         &self,
         message: Message,

--- a/src/framing.rs
+++ b/src/framing.rs
@@ -31,6 +31,7 @@ pub struct FrameHeader {
     ext: u16,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum Frame {
     AMQP(AmqpFrame),

--- a/src/sasl.rs
+++ b/src/sasl.rs
@@ -32,7 +32,7 @@ pub struct SaslClient {
 
 #[derive(Debug)]
 pub struct SaslServer {
-    supported_mechanisms: Vec<SaslMechanism>,
+    _supported_mechanisms: Vec<SaslMechanism>,
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -203,7 +203,7 @@ pub struct Transport<N: Network> {
     network: N,
     incoming: Buffer,
     outgoing: Buffer,
-    max_frame_size: usize,
+    _max_frame_size: usize,
     info: Arc<TransportInfo>,
 }
 
@@ -215,7 +215,7 @@ impl<N: Network> Transport<N> {
             network,
             incoming: Buffer::new(max_frame_size),
             outgoing: Buffer::new(max_frame_size),
-            max_frame_size,
+            _max_frame_size: max_frame_size,
             info: Arc::new(TransportInfo::default()),
         }
     }


### PR DESCRIPTION
This adds a way to check for link credits. This is a workaround until
the send implementation can asyncronously await flow.

Fixes #35