### PR TITLE
Use Vec instead of Array + convenience functions

### DIFF
--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -30,6 +30,7 @@ fn main() {
             Some(SaslMechanism::Plain)
         }),
         idle_timeout: Some(Duration::from_secs(5)),
+        buffer_size: Some(1024 * 512),
     };
 
     let container = Container::new()

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -32,6 +32,7 @@ fn main() {
             Some(SaslMechanism::Plain)
         }),
         idle_timeout: Some(Duration::from_secs(5)),
+        buffer_size: Some(1024 * 512),
     };
 
     let container = Container::new()

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -22,6 +22,7 @@ pub struct ConnectionOptions {
     pub password: Option<String>,
     pub sasl_mechanism: Option<SaslMechanism>,
     pub idle_timeout: Option<Duration>,
+    pub buffer_size: Option<usize>,
 }
 
 impl ConnectionOptions {
@@ -31,6 +32,7 @@ impl ConnectionOptions {
             password: None,
             sasl_mechanism: None,
             idle_timeout: None,
+            buffer_size: None,
         }
     }
 
@@ -40,6 +42,7 @@ impl ConnectionOptions {
             password: None,
             sasl_mechanism: Some(SaslMechanism::Anonymous),
             idle_timeout: None,
+            buffer_size: None,
         }
     }
 
@@ -49,6 +52,7 @@ impl ConnectionOptions {
             password: Some(password),
             sasl_mechanism: Some(SaslMechanism::Plain),
             idle_timeout: None,
+            buffer_size: None,
         }
     }
 
@@ -69,6 +73,13 @@ impl ConnectionOptions {
 
     pub fn idle_timeout(mut self, duration: Duration) -> Self {
         self.idle_timeout = Some(duration);
+        self
+    }
+
+    /// The size of the transport buffer. Messages (including the header) larger
+    /// than the given value cannot be received.
+    pub fn buffer_size(mut self, buffer_size: usize) -> Self {
+        self.buffer_size = Some(buffer_size);
         self
     }
 }

--- a/src/container.rs
+++ b/src/container.rs
@@ -241,7 +241,8 @@ impl ContainerInner {
             move || {
                 let result: Result<_> = (|| {
                     let network = transport::mio::MioNetwork::connect(&host)?;
-                    let transport = transport::Transport::new(network, 1024);
+                    let transport =
+                        transport::Transport::new(network, opts.buffer_size.unwrap_or(1024 * 1024));
                     let connection = conn::connect(transport, opts)?;
                     Ok(connection)
                 })();

--- a/src/types.rs
+++ b/src/types.rs
@@ -217,6 +217,20 @@ impl Value {
     pub fn value_ref(&self) -> ValueRef {
         ValueRef::from(self)
     }
+
+    pub fn as_any_integer(&self) -> Option<i64> {
+        match self {
+            Self::Ubyte(v) => Some(*v as _),
+            Self::Ushort(v) => Some(*v as _),
+            Self::Uint(v) => Some(*v as _),
+            Self::Ulong(v) => Some(*v as _),
+            Self::Byte(v) => Some(*v as _),
+            Self::Short(v) => Some(*v as _),
+            Self::Int(v) => Some(*v as _),
+            Self::Long(v) => Some(*v as _),
+            _ => None,
+        }
+    }
 }
 
 impl From<Symbol> for Value {


### PR DESCRIPTION
 * 04af13fc3da7a9c7a2e7de5260a6e1617ae57248 Move Buffer from stack to heap an increase its default value to 1mib  
 * 5f38d7537eff3316d4ab23f857bd066525249797 Add `Sender::send_with_mode` which accepts `SendMode`
 * c3c183398bec269a4a7d8c7089257070e071658c Fix example for additional buffer size value
 * 5ba9a2ab351c6309fb200b16c4e13ebc6190ab7d Add `Value::as_any_integer(&self) -> Option<i64>` convinience function