### PR TITLE
Return error if Transport::read_frame will never be able to succeed

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -85,6 +85,14 @@ pub enum AmqpError {
     TargetNotRecognized(String),
     #[error("This client does not support the desired SASL mechanism {0:?}")]
     SaslMechanismNotSupported(SaslMechanism),
+
+    #[error(
+        "The AMQP-Message(size={frame_size}) does not fit in the Transport-Buffer(capacity={buffer_capacity})"
+    )]
+    ReceiveBufferHasInsufficientCapacity {
+        frame_size: usize,
+        buffer_capacity: usize,
+    },
 }
 
 impl AmqpError {


### PR DESCRIPTION
Without this fix, the loop within Transport::read_frame will loop
forever trying to fill enough bytes into the incoming-buffer for
the current FrameHeader when `frame_size > buffer.capacity()`.

Sorry, should have committed this yesterday.