### PR TITLE
Upgrade edition to 2021 and fix clippy lints for 1.63

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@
 name = "dove"
 version = "0.2.0"
 authors = ["Ulf Lilleengen <ulf.lilleengen@gmail.com>", "Michael Watzko <michael@watzko.de>"]
-edition = "2018"
+edition = "2021"
 description = "Dove is an open source Rust implementation of the AMQP 1.0 OASIS standard (http://www.amqp.org/)."
 license = "Apache-2.0"
 include = ["README.md", "LICENSE", "src/*.rs", "tests/*.rs", "examples/*.rs"]

--- a/src/container.rs
+++ b/src/container.rs
@@ -579,7 +579,7 @@ impl Session {
 }
 
 /// See also https://access.redhat.com/documentation/en-us/red_hat_amq/7.4/html/amq_clients_overview/amqp
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub enum SendMode {
     /// Also known as "presettled" or "fire and forget".
     /// Sends the message and does not care whether it is received.

--- a/src/decoding.rs
+++ b/src/decoding.rs
@@ -207,9 +207,8 @@ fn decode_value_with_ctor(raw_code: u8, reader: &mut dyn Read) -> Result<Value> 
     }
 }
 
-/**
- * Converts a byte value to a type constructor.
- */
+/// Converts a byte value to a type constructor.
+/// http://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-types-v1.0-csprd01.html#doc-idp280416
 fn decode_type(code: u8) -> Result<TypeCode> {
     match code {
         0x00 => Ok(TypeCode::Described),
@@ -231,8 +230,8 @@ fn decode_type(code: u8) -> Result<TypeCode> {
         0x54 => Ok(TypeCode::Intsmall),
         0x81 => Ok(TypeCode::Long),
         0x55 => Ok(TypeCode::Longsmall),
-        // float
-        // double
+        // 0x72 => Ok(TypeCode::Float),
+        // 0x82 => Ok(TypeCode::Double),
         // decimal32
         // decimal64
         // decimal128

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -493,7 +493,7 @@ impl SessionDriver {
     ) -> Result<(String, Arc<LinkDriver>)> {
         let options = options.into();
         let role = options.role();
-        let link_name = format!("dove-{}-{}", Uuid::new_v4().to_string(), role.as_str());
+        let link_name = format!("dove-{}-{}", Uuid::new_v4(), role.as_str());
         debug!("Creating link {} with role {:?}", link_name, role);
 
         // Send attach frame

--- a/src/framing.rs
+++ b/src/framing.rs
@@ -304,7 +304,7 @@ pub struct Target {
     pub capabilities: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
 pub enum LinkRole {
     Sender,
     Receiver,

--- a/src/options.rs
+++ b/src/options.rs
@@ -72,7 +72,7 @@ impl ApplyOptionsTo<Attach> for LinkOptions {
 }
 
 /// <http://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-messaging-v1.0-os.html#type-node-properties>
-#[derive(Debug, Clone, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
 pub enum DynamicLifetimePolicy {
     DeleteOnClose,
     DeleteOnNoLinks,
@@ -93,7 +93,7 @@ impl DynamicLifetimePolicy {
     }
 }
 
-#[derive(Debug, Clone, PartialOrd, PartialEq)]
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq)]
 pub enum DynamicFlag {
     NotDynamic,
     Dynamic {

--- a/src/sasl.rs
+++ b/src/sasl.rs
@@ -35,14 +35,14 @@ pub struct SaslServer {
     _supported_mechanisms: Vec<SaslMechanism>,
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum SaslState {
     InProgress,
     Success,
     Failed,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum SaslMechanism {
     Anonymous,
     Plain,

--- a/src/types.rs
+++ b/src/types.rs
@@ -250,19 +250,14 @@ impl From<Timestamp> for Value {
 
 impl<V: Into<Value>, const N: usize> From<[V; N]> for Value {
     fn from(array: [V; N]) -> Self {
-        Self::Array(
-            std::array::IntoIter::new(array)
-                .map(Into::into)
-                .collect::<Vec<Value>>(),
-        )
+        Self::Array(array.map(Into::into).to_vec())
     }
 }
 
-/**
- * All basic type codes in AMQP.
- */
+/// All basic type codes in AMQP.
+/// http://docs.oasis-open.org/amqp/core/v1.0/csprd01/amqp-core-types-v1.0-csprd01.html#doc-idp280416
 #[repr(u8)]
-#[derive(Clone, PartialEq, Debug, PartialOrd, Copy)]
+#[derive(Clone, PartialEq, Eq, Debug, PartialOrd, Copy)]
 pub enum TypeCode {
     Described = 0x00,
     Null = 0x40,
@@ -283,8 +278,10 @@ pub enum TypeCode {
     Intsmall = 0x54,
     Long = 0x81,
     Longsmall = 0x55,
-    // float
-    // double
+    // /// IEEE 754-2008 binary32
+    // Float = 0x72,
+    // /// IEEE 754-2008 binary64
+    // Double = 0x82,
     // decimal32
     // decimal32
     // decimal12

--- a/src/url.rs
+++ b/src/url.rs
@@ -7,7 +7,7 @@
 
 use crate::error::*;
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub struct Url<'a> {
     pub scheme: UrlScheme,
     pub username: Option<&'a str>,
@@ -17,7 +17,7 @@ pub struct Url<'a> {
     pub address: &'a str,
 }
 
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum UrlScheme {
     AMQP,
     AMQPS,


### PR DESCRIPTION
Just silencing some (new) compiler & clippy "warnings"