### PR TITLE
Add ` tcp_nodelay` option and fix race condition with deadlock

### DIFF
--- a/examples/receive.rs
+++ b/examples/receive.rs
@@ -31,6 +31,7 @@ fn main() {
         }),
         idle_timeout: Some(Duration::from_secs(5)),
         buffer_size: Some(1024 * 512),
+        tcp_nodelay: None,
     };
 
     let container = Container::new()

--- a/examples/send.rs
+++ b/examples/send.rs
@@ -33,6 +33,7 @@ fn main() {
         }),
         idle_timeout: Some(Duration::from_secs(5)),
         buffer_size: Some(1024 * 512),
+        tcp_nodelay: None,
     };
 
     let container = Container::new()

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -23,6 +23,7 @@ pub struct ConnectionOptions {
     pub sasl_mechanism: Option<SaslMechanism>,
     pub idle_timeout: Option<Duration>,
     pub buffer_size: Option<usize>,
+    pub tcp_nodelay: Option<bool>,
 }
 
 impl ConnectionOptions {
@@ -33,6 +34,7 @@ impl ConnectionOptions {
             sasl_mechanism: None,
             idle_timeout: None,
             buffer_size: None,
+            tcp_nodelay: None,
         }
     }
 
@@ -43,6 +45,7 @@ impl ConnectionOptions {
             sasl_mechanism: Some(SaslMechanism::Anonymous),
             idle_timeout: None,
             buffer_size: None,
+            tcp_nodelay: None,
         }
     }
 
@@ -53,6 +56,7 @@ impl ConnectionOptions {
             sasl_mechanism: Some(SaslMechanism::Plain),
             idle_timeout: None,
             buffer_size: None,
+            tcp_nodelay: None,
         }
     }
 
@@ -80,6 +84,12 @@ impl ConnectionOptions {
     /// than the given value cannot be received.
     pub fn buffer_size(mut self, buffer_size: usize) -> Self {
         self.buffer_size = Some(buffer_size);
+        self
+    }
+
+    /// See [`std::net::TcpStream::set_nodelay`]
+    pub fn tcp_nodelay(mut self, nodelay: bool) -> Self {
+        self.tcp_nodelay = Some(nodelay);
         self
     }
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -28,7 +28,7 @@ impl ConnectionHandle {
 
     pub fn begin(&self, channel: ChannelId, begin: Begin) -> Result<()> {
         self.send_amqp_frame(AmqpFrame {
-            channel: channel as u16,
+            channel,
             performative: Some(Performative::Begin(begin)),
             payload: None,
         })
@@ -36,7 +36,7 @@ impl ConnectionHandle {
 
     pub fn attach(&self, channel: ChannelId, attach: Attach) -> Result<()> {
         self.send_amqp_frame(AmqpFrame {
-            channel: channel as u16,
+            channel,
             performative: Some(Performative::Attach(attach)),
             payload: None,
         })
@@ -44,7 +44,7 @@ impl ConnectionHandle {
 
     pub fn flow(&self, channel: ChannelId, flow: Flow) -> Result<()> {
         self.send_amqp_frame(AmqpFrame {
-            channel: channel as u16,
+            channel,
             performative: Some(Performative::Flow(flow)),
             payload: None,
         })
@@ -57,7 +57,7 @@ impl ConnectionHandle {
         payload: Option<Vec<u8>>,
     ) -> Result<()> {
         self.send_amqp_frame(AmqpFrame {
-            channel: channel as u16,
+            channel,
             performative: Some(Performative::Transfer(transfer)),
             payload,
         })
@@ -65,7 +65,7 @@ impl ConnectionHandle {
 
     pub fn disposition(&self, channel: ChannelId, disposition: Disposition) -> Result<()> {
         self.send_amqp_frame(AmqpFrame {
-            channel: channel as u16,
+            channel,
             performative: Some(Performative::Disposition(disposition)),
             payload: None,
         })
@@ -92,7 +92,7 @@ impl ConnectionHandle {
 
     pub fn detach(&self, channel: ChannelId, detach: Detach) -> Result<()> {
         self.send_amqp_frame(AmqpFrame {
-            channel: channel as u16,
+            channel,
             performative: Some(Performative::Detach(detach)),
             payload: None,
         })
@@ -100,7 +100,7 @@ impl ConnectionHandle {
 
     pub fn end(&self, channel: ChannelId, end: End) -> Result<()> {
         self.send_amqp_frame(AmqpFrame {
-            channel: channel as u16,
+            channel,
             performative: Some(Performative::End(end)),
             payload: None,
         })

--- a/src/container.rs
+++ b/src/container.rs
@@ -241,6 +241,11 @@ impl ContainerInner {
             move || {
                 let result: Result<_> = (|| {
                     let network = transport::mio::MioNetwork::connect(&host)?;
+
+                    if let Some(nodelay) = opts.tcp_nodelay {
+                        network.set_nodelay(nodelay)?;
+                    }
+
                     let transport =
                         transport::Transport::new(network, opts.buffer_size.unwrap_or(1024 * 1024));
                     let connection = conn::connect(transport, opts)?;

--- a/src/container.rs
+++ b/src/container.rs
@@ -241,11 +241,6 @@ impl ContainerInner {
             move || {
                 let result: Result<_> = (|| {
                     let network = transport::mio::MioNetwork::connect(&host)?;
-
-                    if let Some(nodelay) = opts.tcp_nodelay {
-                        network.set_nodelay(nodelay)?;
-                    }
-
                     let transport =
                         transport::Transport::new(network, opts.buffer_size.unwrap_or(1024 * 1024));
                     let connection = conn::connect(transport, opts)?;

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -780,6 +780,9 @@ impl LinkDriver {
         settled: bool,
         state: DeliveryState,
     ) -> Result<()> {
+        if settled {
+            self.session_flow_control.lock().unwrap().incoming_window += 1;
+        }
         self.connection().disposition(
             self.channel,
             framing::Disposition {

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -740,7 +740,7 @@ impl LinkDriver {
                 incoming_window: props.incoming_window,
                 next_outgoing_id: props.next_outgoing_id,
                 outgoing_window: props.outgoing_window,
-                handle: Some(self.handle as u32),
+                handle: Some(self.handle),
                 delivery_count: Some(self.delivery_count.load(Ordering::SeqCst)),
                 link_credit: Some(credit),
                 available: None,

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -677,15 +677,14 @@ impl LinkDriver {
         }
 
         // Session flow control
-        let next_outgoing_id;
-        loop {
+        let next_outgoing_id = loop {
             let props = self.session_flow_control.lock().unwrap().next();
             if let Some(props) = props {
-                next_outgoing_id = props.next_outgoing_id;
-                break;
+                break props.next_outgoing_id;
             }
+            warn!("No next_outgoing_id, busy looping");
             // std::thread::sleep(Duration::from_millis(500));
-        }
+        };
 
         self.delivery_count.fetch_add(1, Ordering::SeqCst);
         let delivery_tag = rand::thread_rng().gen::<[u8; 16]>().to_vec();

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -773,28 +773,24 @@ impl LinkDriver {
         self.rx.send(frame)
     }
 
+    #[inline]
     pub fn disposition(
         &self,
         delivery: &DeliveryDriver,
         settled: bool,
         state: DeliveryState,
     ) -> Result<()> {
-        if settled {
-            self.did_to_delivery.lock().unwrap().remove(&delivery.id);
-            let mut control = self.session_flow_control.lock().unwrap();
-            control.incoming_window += 1;
-        }
-        let disposition = framing::Disposition {
-            role: self.role,
-            first: delivery.id,
-            last: Some(delivery.id),
-            settled: Some(settled),
-            state: Some(state),
-            batchable: None,
-        };
-
-        self.connection().disposition(self.channel, disposition)?;
-        Ok(())
+        self.connection().disposition(
+            self.channel,
+            framing::Disposition {
+                role: self.role,
+                first: delivery.id,
+                last: Some(delivery.id),
+                settled: Some(settled),
+                state: Some(state),
+                batchable: None,
+            },
+        )
     }
 }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -356,6 +356,11 @@ pub mod mio {
             )?;
             Ok(())
         }
+
+        /// See [`TcpStream::set_nodelay`]
+        pub fn set_nodelay(&self, nodelay: bool) -> Result<()> {
+            Ok(self.stream.set_nodelay(nodelay)?)
+        }
     }
 
     impl Network for MioNetwork {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -158,6 +158,10 @@ impl Write for Buffer {
 }
 
 pub trait Network: Read + Write + Debug {
+    /// See [`std::net::TcpStream::set_nodelay`]. Depending on the implementation (mio+windows: [`::mio::net::TcpStream::set_nodelay`]),
+    /// this shall not be set before the network is connected.
+    fn set_nodelay(&self, nodelay: bool) -> Result<()>;
+
     fn close(&mut self) -> Result<()>;
 }
 
@@ -364,6 +368,11 @@ pub mod mio {
     }
 
     impl Network for MioNetwork {
+        fn set_nodelay(&self, nodelay: bool) -> Result<()> {
+            self.stream.set_nodelay(nodelay)?;
+            Ok(())
+        }
+
         fn close(&mut self) -> Result<()> {
             self.stream.shutdown(Shutdown::Both)?;
             Ok(())

--- a/src/url.rs
+++ b/src/url.rs
@@ -56,7 +56,7 @@ impl Url<'_> {
         let (input, hostname, port) = if let Some(pos) = input.find(':') {
             let (hostname, input) = (&input[0..pos], &input[pos + 1..]);
             let (input, port) = if let Some(end_pos) = input.find('/') {
-                (&input[end_pos + 1..], (&input[..end_pos]).parse::<u16>()?)
+                (&input[end_pos + 1..], input[..end_pos].parse::<u16>()?)
             } else {
                 ("", input.parse::<u16>()?)
             };


### PR DESCRIPTION
Besides smaller cleanup commits:
 * [Fix needless_borrow clippy warning](https://github.com/lulf/dove/commit/bf430343fe525010b9a1e65b0b3e5d138b6cc038)
 * [Warn on no next_outgoing_id](https://github.com/lulf/dove/commit/6db37582228c35f0b7e7536581c9681d9c0baaac)
 * [Fix clippy lints](https://github.com/lulf/dove/commit/4844dc298b516c54ad63c0ad421adb8158e52d5b)

This PR adds a `tcp_nodelay` option to `ConnectionOptions` 
 * [Add tcp_nodelay to ConnectionOptions](https://github.com/lulf/dove/commit/23c63e3234c8e322229b9a31912ef021365114a6)
 * [Set tcp_nodelay only after the connection was established (req by windows)](https://github.com/lulf/dove/commit/0b5a5702b29f12317bcd93e722e097c8838dec01) 



And fixes a race condition that could lead to a deadlock in sending messages:
 * [Dont interfer in the removal of deliver-id mappings of sent messages](https://github.com/lulf/dove/commit/6dfe93866501e863cef7e0fd8aad8733483484d8)

I'd like to discuss the race condition fix. For me the `.remove` call on `did_to_delivery` caused by the received messages seems to be "obviously" wrong: the mapping in `did_to_delivery` is only for sent/outgoing messages. A scenerio with a lot of messages being received and transmitted seems to run into an id-clash and results in a deadlock. Consider the following scenario:
 - A message is received. [The `delivery_id` is rememberd](https://github.com/lulf/dove/blob/main/src/container.rs#L705).
 - A new message [shall be sent](https://github.com/lulf/dove/blob/main/src/container.rs#L629). The [`next_outgoing_id`](https://github.com/lulf/dove/blob/main/src/driver.rs#L680) has by chance the same value as the `delivery_id` from the just received message. [An id-mapping is added for said `next_outgoing_id`](https://github.com/lulf/dove/blob/main/src/driver.rs#L702).
 - The `Delivery`-Container of the received message [is dropped](https://github.com/lulf/dove/blob/main/src/container.rs#L769). This results in a call to [remove the id-mapping for its `delivery_id`](https://github.com/lulf/dove/blob/main/src/driver.rs#L784).
 - The send-operation now expectes an response for its tranmissions, but waits forever [here](https://github.com/lulf/dove/blob/main/src/container.rs#L637) because it cannot [be deliverd](https://github.com/lulf/dove/blob/main/src/driver.rs#L442) because of the broken mapping.

Not so sure about the removal of the `incoming_window` increment. But this seems also to be updated via `SessionFlowControl::accept` ([driver.rs:96](https://github.com/lulf/dove/blob/main/src/driver.rs#L96)), which in turn is called in [line 389](https://github.com/lulf/dove/blob/main/src/driver.rs#L389).

Could you comment on my assumptions?